### PR TITLE
Add EventHandler class

### DIFF
--- a/lycee-filterflow/LyceeFilterFlow.cpp
+++ b/lycee-filterflow/LyceeFilterFlow.cpp
@@ -11,7 +11,8 @@ lycee::LyceeFilterFlow::LyceeFilterFlow(HINSTANCE hInstance)
 	: lycee::widgets::Application(hInstance),
 	input(NULL),
 	output(NULL),
-	filterList()
+	filterList(),
+	eventHandler(DefWindowProc)
 {
 }
 
@@ -25,6 +26,10 @@ BOOL lycee::LyceeFilterFlow::start(const lycee_string &title, int width, int hei
 	) {
 		return FALSE;
 	}
+	
+	setupEvent();
+	entryEventHandler(&eventHandler);
+
 	return this->run(title, width, height, nCmdShow);
 }
 

--- a/lycee-filterflow/LyceeFilterFlow.h
+++ b/lycee-filterflow/LyceeFilterFlow.h
@@ -15,19 +15,23 @@ namespace lycee {
 
 		BOOL start(const lycee_string &title, int width, int height, int nCmdShow);
 
-
+	// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+	// dispatch event
 	protected:
-		virtual LRESULT dispatchEvent(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
-
-		virtual LRESULT doCreate(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
-		virtual LRESULT doDestroy(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
-		virtual LRESULT doPaint(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+		virtual LRESULT doCreate(lycee::widgets::EventInfo info);
+		virtual LRESULT doDestroy(lycee::widgets::EventInfo info);
+		virtual LRESULT doPaint(lycee::widgets::EventInfo info);
 		
-		virtual LRESULT doCommand(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+		virtual LRESULT doCommand(lycee::widgets::EventInfo info);
 
-		virtual LRESULT doLButtonDown(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
-		virtual LRESULT doMouseMove(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
-		virtual LRESULT doLButtonUp(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+		virtual LRESULT doLButtonDown(lycee::widgets::EventInfo info);
+		virtual LRESULT doMouseMove(lycee::widgets::EventInfo info);
+		virtual LRESULT doLButtonUp(lycee::widgets::EventInfo info);
+
+	private:
+		lycee::widgets::CommonEventHandler eventHandler;
+
+		void setupEvent();
 
 	private:
 		std::deque<lycee::filtergraph::PanelViewFactory*> factories;

--- a/lycee-filterflow/LyceeFilterFlow.h
+++ b/lycee-filterflow/LyceeFilterFlow.h
@@ -19,6 +19,7 @@ namespace lycee {
 	// dispatch event
 	protected:
 		virtual LRESULT doCreate(lycee::widgets::EventInfo info);
+		virtual LRESULT doClose(lycee::widgets::EventInfo info);
 		virtual LRESULT doDestroy(lycee::widgets::EventInfo info);
 		virtual LRESULT doPaint(lycee::widgets::EventInfo info);
 		
@@ -60,7 +61,7 @@ namespace lycee {
 	// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 	// Context Menu Event
 	public:
-		virtual LRESULT doRButtonDown(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+		virtual LRESULT doRButtonDown(lycee::widgets::EventInfo info);
 
 	private:
 		lycee::widgets::PopupMenu *popupMenu;

--- a/lycee-filterflow/LyceeFilterFlow_Event.cpp
+++ b/lycee-filterflow/LyceeFilterFlow_Event.cpp
@@ -7,6 +7,8 @@ void lycee::LyceeFilterFlow::setupEvent()
 #define CALL_EVENT(e) [&](lycee::widgets::EventInfo i) {return e(i); }
 
 	this->eventHandler.entryEvent(WM_DESTROY, CALL_EVENT(this->doDestroy));
+	this->eventHandler.entryEvent(WM_CLOSE, CALL_EVENT(this->doClose));
+
 	this->eventHandler.entryEvent(WM_CREATE, CALL_EVENT(this->doCreate));
 	this->eventHandler.entryEvent(WM_PAINT, CALL_EVENT(this->doPaint));
 
@@ -15,10 +17,18 @@ void lycee::LyceeFilterFlow::setupEvent()
 	this->eventHandler.entryEvent(WM_MOUSEMOVE, CALL_EVENT(this->doMouseMove));
 	this->eventHandler.entryEvent(WM_LBUTTONDOWN, CALL_EVENT(this->doLButtonDown));
 	this->eventHandler.entryEvent(WM_LBUTTONUP, CALL_EVENT(this->doLButtonUp));
+	this->eventHandler.entryEvent(WM_RBUTTONDOWN, CALL_EVENT(this->doRButtonDown));
 
 #undef CALL_EVENT
 }
 
+LRESULT lycee::LyceeFilterFlow::doClose(lycee::widgets::EventInfo info)
+{
+	if (IDOK != lycee::widgets::MessageDialog::confirm(info.hWnd, TEXT("終了しますか？"))) {
+		return 0L;
+	}
+	return info.callDefault();
+}
 
 LRESULT lycee::LyceeFilterFlow::doDestroy(lycee::widgets::EventInfo info)
 {
@@ -120,9 +130,7 @@ LRESULT lycee::LyceeFilterFlow::doCommand(lycee::widgets::EventInfo info)
 		saveDialog();
 		return 0L;
 	case ID_FILE_QUIT:
-		if(IDOK == lycee::widgets::MessageDialog::confirm(info.hWnd, TEXT("終了しますか？"))) {
-			DestroyWindow(info.hWnd);
-		}
+		info.send(WM_CLOSE);
 		return 0L;
 
 	case ID_ADDPANEL_FILTER:

--- a/lycee-filterflow/LyceeFilterFlow_Event.cpp
+++ b/lycee-filterflow/LyceeFilterFlow_Event.cpp
@@ -2,31 +2,25 @@
 
 #include "resource.h"
 
-
-LRESULT lycee::LyceeFilterFlow::dispatchEvent(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+void lycee::LyceeFilterFlow::setupEvent()
 {
-	switch (uMsg) {
-	case WM_CREATE:
-		return this->doCreate(hWnd, uMsg, wp, lp);
-	case WM_PAINT:
-		return this->doPaint(hWnd, uMsg, wp, lp);
-	case WM_COMMAND:
-		return this->doCommand(hWnd, uMsg, wp, lp);
-	case WM_DESTROY:
-		return this->doDestroy(hWnd, uMsg, wp, lp);
-	case WM_MOUSEMOVE:
-		return this->doMouseMove(hWnd, uMsg, wp, lp);
-	case WM_LBUTTONDOWN:
-		return this->doLButtonDown(hWnd, uMsg, wp, lp);
-	case WM_LBUTTONUP:
-		return this->doLButtonUp(hWnd, uMsg, wp, lp);
-	case WM_RBUTTONDOWN:
-		return this->doRButtonDown(hWnd, uMsg, wp, lp);
-	}
-	return DefWindowProc(hWnd, uMsg, wp, lp);
+#define CALL_EVENT(e) [&](lycee::widgets::EventInfo i) {return e(i); }
+
+	this->eventHandler.entryEvent(WM_DESTROY, CALL_EVENT(this->doDestroy));
+	this->eventHandler.entryEvent(WM_CREATE, CALL_EVENT(this->doCreate));
+	this->eventHandler.entryEvent(WM_PAINT, CALL_EVENT(this->doPaint));
+
+	this->eventHandler.entryEvent(WM_COMMAND, CALL_EVENT(this->doCommand));
+
+	this->eventHandler.entryEvent(WM_MOUSEMOVE, CALL_EVENT(this->doMouseMove));
+	this->eventHandler.entryEvent(WM_LBUTTONDOWN, CALL_EVENT(this->doLButtonDown));
+	this->eventHandler.entryEvent(WM_LBUTTONUP, CALL_EVENT(this->doLButtonUp));
+
+#undef CALL_EVENT
 }
 
-LRESULT lycee::LyceeFilterFlow::doDestroy(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+
+LRESULT lycee::LyceeFilterFlow::doDestroy(lycee::widgets::EventInfo info)
 {
 	delete input;
 	for (auto iter = this->filterList.begin(); iter != this->filterList.end(); iter++) {
@@ -40,10 +34,11 @@ LRESULT lycee::LyceeFilterFlow::doDestroy(HWND hWnd, UINT uMsg, WPARAM wp, LPARA
 	factories.clear();
 
 	delete popupMenu;
+	info.quit();
 	return 0L;
 }
 
-LRESULT lycee::LyceeFilterFlow::doCreate(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+LRESULT lycee::LyceeFilterFlow::doCreate(lycee::widgets::EventInfo info)
 {
 	factories.push_back(new lycee::filtergraph::InputPanelViewFactory(TEXT("Input[%03d]")));
 	factories.push_back(new lycee::filtergraph::OutputPanelViewFactory(TEXT("Output[%03d]")));
@@ -78,9 +73,9 @@ LRESULT lycee::LyceeFilterFlow::doCreate(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM
 	return 0L;
 }
 
-LRESULT lycee::LyceeFilterFlow::doPaint(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+LRESULT lycee::LyceeFilterFlow::doPaint(lycee::widgets::EventInfo info)
 {
-	lycee::graphics::WindowPainter painter(hWnd);
+	lycee::graphics::WindowPainter painter(info.hWnd);
 
 	input->render(&painter);
 	for (auto iter = this->filterList.begin(); iter != this->filterList.end(); iter++) {
@@ -107,11 +102,11 @@ void lycee::LyceeFilterFlow::saveDialog()
 	}
 }
 
-LRESULT lycee::LyceeFilterFlow::doCommand(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+LRESULT lycee::LyceeFilterFlow::doCommand(lycee::widgets::EventInfo info)
 {
 	lycee_string msg;
 
-	switch (LOWORD(wp)) {
+	switch (LOWORD(info.wParam)) {
 	case ID_FILE_NEW:
 		msg = TEXT("[File]>[NEW]");
 		break;
@@ -125,8 +120,8 @@ LRESULT lycee::LyceeFilterFlow::doCommand(HWND hWnd, UINT uMsg, WPARAM wp, LPARA
 		saveDialog();
 		return 0L;
 	case ID_FILE_QUIT:
-		if(IDOK == lycee::widgets::MessageDialog::confirm(hWnd, TEXT("終了しますか？"))) {
-			DestroyWindow(hWnd);
+		if(IDOK == lycee::widgets::MessageDialog::confirm(info.hWnd, TEXT("終了しますか？"))) {
+			DestroyWindow(info.hWnd);
 		}
 		return 0L;
 
@@ -146,15 +141,15 @@ LRESULT lycee::LyceeFilterFlow::doCommand(HWND hWnd, UINT uMsg, WPARAM wp, LPARA
 	}
 
 	if (!msg.empty()) {
-		MessageBox(hWnd, msg.c_str(), TEXT("確認"), MB_OK);
+		lycee::widgets::MessageDialog::info(info.hWnd, msg);
 	}
 	return 0L;
 }
 
-LRESULT lycee::LyceeFilterFlow::doLButtonDown(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+LRESULT lycee::LyceeFilterFlow::doLButtonDown(lycee::widgets::EventInfo info)
 {
-	long x = LOWORD(lp);
-	long y = HIWORD(lp);
+	long x = LOWORD(info.lParam);
+	long y = HIWORD(info.lParam);
 	
 	this->dragging = NULL;
 	this->isDragging = false;
@@ -187,14 +182,14 @@ LRESULT lycee::LyceeFilterFlow::doLButtonDown(HWND hWnd, UINT uMsg, WPARAM wp, L
 	return 0L;
 }
 
-LRESULT lycee::LyceeFilterFlow::doMouseMove(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+LRESULT lycee::LyceeFilterFlow::doMouseMove(lycee::widgets::EventInfo info)
 {
 	if (!this->isDragging) {
 		return 0L;
 	}
 
-	long x = LOWORD(lp);
-	long y = HIWORD(lp);
+	long x = LOWORD(info.lParam);
+	long y = HIWORD(info.lParam);
 
 	long dx = x - this->ptStartMouse.x;
 	long dy = y - this->ptStartMouse.y;
@@ -204,12 +199,12 @@ LRESULT lycee::LyceeFilterFlow::doMouseMove(HWND hWnd, UINT uMsg, WPARAM wp, LPA
 
 	this->dragging->moveTo(newX, newY);
 
-	InvalidateRect(hWnd, NULL, TRUE);
-
+	info.invalidate(true);
+	
 	return 0L;
 }
 
-LRESULT lycee::LyceeFilterFlow::doLButtonUp(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+LRESULT lycee::LyceeFilterFlow::doLButtonUp(lycee::widgets::EventInfo info)
 {
 	this->dragging = NULL;
 	this->isDragging = false;

--- a/lycee-filterflow/LyceeFilterFlow_Menu.cpp
+++ b/lycee-filterflow/LyceeFilterFlow_Menu.cpp
@@ -2,8 +2,8 @@
 
 
 
-LRESULT lycee::LyceeFilterFlow::doRButtonDown(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+LRESULT lycee::LyceeFilterFlow::doRButtonDown(lycee::widgets::EventInfo info)
 {
-	popupMenu->show(hWnd, POINT{LOWORD(lp), HIWORD(lp)});
+	popupMenu->show(info.hWnd, POINT{LOWORD(info.lParam), HIWORD(info.lParam)});
 	return 0L;
 }

--- a/lycee-filterflow/lycee-filterflow.vcxproj
+++ b/lycee-filterflow/lycee-filterflow.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="lycee\widgets.h" />
     <ClInclude Include="lycee\widgets\Application.h" />
     <ClInclude Include="lycee\widgets\Dialog.h" />
+    <ClInclude Include="lycee\widgets\EventHandlers.h" />
     <ClInclude Include="lycee\widgets\Menus.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
@@ -162,6 +163,7 @@
     <ClCompile Include="lycee\images\ImageProcessor.cpp" />
     <ClCompile Include="lycee\widgets\Application.cpp" />
     <ClCompile Include="lycee\widgets\Dialog.cpp" />
+    <ClCompile Include="lycee\widgets\EventHandlers.cpp" />
     <ClCompile Include="lycee\widgets\MainEventController.cpp" />
     <ClCompile Include="lycee\widgets\Menus.cpp" />
     <ClCompile Include="Program.cpp" />

--- a/lycee-filterflow/lycee-filterflow.vcxproj.filters
+++ b/lycee-filterflow/lycee-filterflow.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClInclude Include="lycee\images.h">
       <Filter>ヘッダー ファイル\images</Filter>
     </ClInclude>
+    <ClInclude Include="lycee\widgets\EventHandlers.h">
+      <Filter>ヘッダー ファイル\widgets</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="LyceeFilterFlow.cpp">
@@ -159,6 +162,9 @@
     </ClCompile>
     <ClCompile Include="lycee\images\ImageProcessor.cpp">
       <Filter>ソース ファイル\images</Filter>
+    </ClCompile>
+    <ClCompile Include="lycee\widgets\EventHandlers.cpp">
+      <Filter>ソース ファイル\widgets</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/lycee-filterflow/lycee/widgets.h
+++ b/lycee-filterflow/lycee/widgets.h
@@ -7,5 +7,6 @@
 
 #include "widgets\Menus.h"
 
+#include "widgets\EventHandlers.h"
 
 #endif	// __LYCEE__WIDGETS__HEADER__

--- a/lycee-filterflow/lycee/widgets/Application.cpp
+++ b/lycee-filterflow/lycee/widgets/Application.cpp
@@ -1,5 +1,7 @@
 #include "Application.h"
 
+#include "EventHandlers.h"
+
 
 lycee::widgets::Application::~Application()
 {
@@ -9,7 +11,8 @@ lycee::widgets::Application::~Application()
 lycee::widgets::Application::Application(HINSTANCE hInstance)
 	: atom(INVALID_ATOM),
 	hInstance(hInstance),
-	hWnd(NULL)
+	hWnd(NULL),
+	eventHandler(NULL)
 {
 	;
 }
@@ -32,7 +35,7 @@ BOOL lycee::widgets::Application::initialize(LPCTSTR lpszClassName, LPCTSTR lpsz
 	wcex.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
 	wcex.hInstance = hInstance;
 
-	wcex.lpfnWndProc = MainEventController;
+	wcex.lpfnWndProc = MainEventController::GlobalWndProc;
 	wcex.lpszClassName = lpszClassName;
 	wcex.lpszMenuName = lpszMenuName;
 	wcex.style = style;
@@ -86,6 +89,23 @@ void lycee::widgets::Application::release()
 	UnregisterClass(MAKEINTATOM(this->atom), this->hInstance);
 	this->atom = INVALID_ATOM;
 }
+
+
+LRESULT lycee::widgets::Application::dispatchEvent(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+{
+	if (eventHandler) {
+		auto result = eventHandler->dispatch(hWnd, uMsg, wp, lp);
+		return trif(result.has_value(), result.value(), 0L);
+	}
+	return DefWindowProc(hWnd, uMsg, wp, lp);
+
+}
+
+void lycee::widgets::Application::entryEventHandler(lycee::widgets::EventHandler *handler)
+{
+	this->eventHandler = handler;
+}
+
 
 
 RECT lycee::widgets::Application::adjustWindowRect(int width, int height, DWORD dwStyle, BOOL bMenu)

--- a/lycee-filterflow/lycee/widgets/Application.h
+++ b/lycee-filterflow/lycee/widgets/Application.h
@@ -8,10 +8,20 @@ namespace lycee {
 
 	namespace widgets {
 
+		class EventHandler;
+
 		class Application {
+		// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+		// constructor/destructor
+		// 
 		public:
 			virtual ~Application();
 			explicit Application(HINSTANCE hInstance);
+
+		// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+		// Application controller
+		//
+		public:
 
 			BOOL initialize(LPCTSTR lpszClassName, LPCTSTR lpszMenuName, UINT style);
 
@@ -27,9 +37,6 @@ namespace lycee {
 				return this->hInstance;
 			}
 
-		protected:
-			virtual LRESULT dispatchEvent(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp) = 0;
-
 		private:
 			ATOM atom;
 			HINSTANCE hInstance;
@@ -38,14 +45,38 @@ namespace lycee {
 
 			RECT adjustWindowRect(int width, int height, DWORD dwStyle, BOOL bMenu);
 
+
+		// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+		// event dispatcher
+		//
+		public:
+			void entryEventHandler(EventHandler *handler);
+
+			virtual LRESULT dispatchEvent(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+
 		private:
+			EventHandler *eventHandler;
+
+		};
+
+		// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+		// [MAIN EVENT CONTROLLER]
+		//
+		class MainEventController {
+			friend class Application;
+
+		private:
+			~MainEventController();
+			MainEventController();
+			MainEventController(const MainEventController &);
+			MainEventController& operator =(const MainEventController &);
+
 			typedef std::map<HWND, Application*> application_map;
 			typedef typename application_map::iterator map_iterator;
 
 			static std::map<HWND, Application*> applicationList;
-			static LRESULT CALLBACK MainEventController(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+			static LRESULT CALLBACK GlobalWndProc(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
 		};
-
 
 	}	// widgets
 

--- a/lycee-filterflow/lycee/widgets/EventHandlers.cpp
+++ b/lycee-filterflow/lycee/widgets/EventHandlers.cpp
@@ -15,8 +15,9 @@ lycee::widgets::CommonEventHandler::~CommonEventHandler()
 {
 }
 
-lycee::widgets::CommonEventHandler::CommonEventHandler()
-	: eventList()
+lycee::widgets::CommonEventHandler::CommonEventHandler(default_callback _default)
+	: defaultCallback(_default),
+	eventList()
 {
 }
 
@@ -30,6 +31,9 @@ std::optional<LRESULT> lycee::widgets::CommonEventHandler::dispatch(HWND hWnd, U
 			result = iter->second(info);
 		}
 		hookAfterInvoke(&info);
+	}
+	else {
+		result = this->defaultCallback(hWnd, uMsg, wp, lp);
 	}
 	return result;
 }

--- a/lycee-filterflow/lycee/widgets/EventHandlers.cpp
+++ b/lycee-filterflow/lycee/widgets/EventHandlers.cpp
@@ -1,0 +1,75 @@
+#include "EventHandlers.h"
+
+// ================================================================================
+// EventHandler class
+// ================================================================================
+
+lycee::widgets::EventHandler::~EventHandler() { }
+
+
+// ================================================================================
+// CommonEventHandler class
+// ================================================================================
+
+lycee::widgets::CommonEventHandler::~CommonEventHandler()
+{
+}
+
+lycee::widgets::CommonEventHandler::CommonEventHandler()
+	: eventList()
+{
+}
+
+std::optional<LRESULT> lycee::widgets::CommonEventHandler::dispatch(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+{
+	std::optional<LRESULT> result;
+	auto iter = this->eventList.find(uMsg);
+	if (iter != this->eventList.end()) {
+		EventInfo info = createEventInfo(hWnd, uMsg, wp, lp);
+		if (hookBeforeInvoke(&info)) {
+			result = iter->second(info);
+		}
+		hookAfterInvoke(&info);
+	}
+	return result;
+}
+
+void lycee::widgets::CommonEventHandler::entryEvent(UINT id, std::function<LRESULT(EventInfo)> callback)
+{
+	this->eventList[id] = callback;
+}
+
+void lycee::widgets::CommonEventHandler::clear()
+{
+	this->eventList.clear();
+}
+
+void lycee::widgets::CommonEventHandler::remove(UINT id)
+{
+	this->eventList.erase(id);
+}
+
+bool lycee::widgets::CommonEventHandler::hasId(UINT id)
+{
+	return (this->eventList.find(id) != this->eventList.end());
+}
+
+lycee::widgets::EventInfo lycee::widgets::CommonEventHandler::createEventInfo(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+{
+	lycee::widgets::EventInfo info;
+	info.hWnd = hWnd;
+	info.uMsg = uMsg;
+	info.wParam = wp;
+	info.lParam = lp;
+	return info;
+}
+
+bool lycee::widgets::CommonEventHandler::hookBeforeInvoke(EventInfo *info)
+{
+	return true;
+}
+
+void lycee::widgets::CommonEventHandler::hookAfterInvoke(EventInfo *info)
+{
+	return;
+}

--- a/lycee-filterflow/lycee/widgets/EventHandlers.h
+++ b/lycee-filterflow/lycee/widgets/EventHandlers.h
@@ -14,7 +14,7 @@ namespace lycee {
 			WPARAM wParam;
 			LPARAM lParam;
 
-			virtual LRESULT dispatch() {
+			virtual LRESULT callDefault() {
 				return DefWindowProc(hWnd, uMsg, wParam, lParam);
 			}
 
@@ -28,6 +28,14 @@ namespace lycee {
 
 			void quit(int nExitCode = 0) {
 				PostQuitMessage(nExitCode);
+			}
+
+			LRESULT send(UINT uMsg, WPARAM wp = 0U, LPARAM lp = 0L) {
+				return SendMessage(hWnd, uMsg, wp, lp);
+			}
+
+			BOOL post(UINT uMsg, WPARAM wp = 0U, LPARAM lp = 0L) {
+				return PostMessage(hWnd, uMsg, wp, lp);
 			}
 		};
 

--- a/lycee-filterflow/lycee/widgets/EventHandlers.h
+++ b/lycee-filterflow/lycee/widgets/EventHandlers.h
@@ -17,6 +17,18 @@ namespace lycee {
 			virtual LRESULT dispatch() {
 				return DefWindowProc(hWnd, uMsg, wParam, lParam);
 			}
+
+			BOOL invalidate(const RECT *lpRect, bool bErase) {
+				return InvalidateRect(hWnd, lpRect, bErase);
+			}
+
+			BOOL invalidate(bool bErase) {
+				return invalidate(NULL, bErase);
+			}
+
+			void quit(int nExitCode = 0) {
+				PostQuitMessage(nExitCode);
+			}
 		};
 
 
@@ -33,11 +45,12 @@ namespace lycee {
 
 		class CommonEventHandler : public virtual EventHandler {
 		public:
+			typedef WNDPROC default_callback;
 			typedef std::function<LRESULT(EventInfo)> callback_type;
 			
 			virtual ~CommonEventHandler();
 
-			CommonEventHandler();
+			explicit CommonEventHandler(default_callback _default);
 
 			virtual std::optional<LRESULT> dispatch(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
 
@@ -48,7 +61,7 @@ namespace lycee {
 			void remove(UINT id);
 
 			bool hasId(UINT id);
-
+			
 		protected:
 			virtual EventInfo createEventInfo(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
 
@@ -57,6 +70,7 @@ namespace lycee {
 			virtual void hookAfterInvoke(EventInfo *info);
 
 		private:
+			default_callback defaultCallback;
 			std::map<UINT, callback_type> eventList;
 
 		};

--- a/lycee-filterflow/lycee/widgets/EventHandlers.h
+++ b/lycee-filterflow/lycee/widgets/EventHandlers.h
@@ -1,0 +1,68 @@
+#ifndef __LYCEE__WIDGETS__EVENT_HANDLER__HEADER__
+#define __LYCEE__WIDGETS__EVENT_HANDLER__HEADER__
+
+#include "..\includes.h"
+
+
+namespace lycee {
+
+	namespace widgets {
+
+		struct EventInfo {
+			HWND hWnd;
+			UINT uMsg;
+			WPARAM wParam;
+			LPARAM lParam;
+
+			virtual LRESULT dispatch() {
+				return DefWindowProc(hWnd, uMsg, wParam, lParam);
+			}
+		};
+
+
+		// ====================================================================================
+		// EventHandler class
+		// ====================================================================================
+		class EventHandler {
+		public:
+			virtual ~EventHandler() = 0;
+
+			virtual std::optional<LRESULT> dispatch(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp) = 0;
+		};
+
+
+		class CommonEventHandler : public virtual EventHandler {
+		public:
+			typedef std::function<LRESULT(EventInfo)> callback_type;
+			
+			virtual ~CommonEventHandler();
+
+			CommonEventHandler();
+
+			virtual std::optional<LRESULT> dispatch(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+
+			void entryEvent(UINT id, std::function<LRESULT(EventInfo)> callback);
+			
+			void clear();
+
+			void remove(UINT id);
+
+			bool hasId(UINT id);
+
+		protected:
+			virtual EventInfo createEventInfo(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp);
+
+			virtual bool hookBeforeInvoke(EventInfo *info);
+
+			virtual void hookAfterInvoke(EventInfo *info);
+
+		private:
+			std::map<UINT, callback_type> eventList;
+
+		};
+
+
+	}	// widgets
+
+}	// lycee
+#endif	// __LYCEE__WIDGETS__EVENT_HANDLER__HEADER__

--- a/lycee-filterflow/lycee/widgets/MainEventController.cpp
+++ b/lycee-filterflow/lycee/widgets/MainEventController.cpp
@@ -1,9 +1,27 @@
 #include "Application.h"
 
 
-std::map<HWND, lycee::widgets::Application*> lycee::widgets::Application::applicationList;
+lycee::widgets::MainEventController::~MainEventController()
+{
+}
 
-LRESULT CALLBACK lycee::widgets::Application::MainEventController(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
+lycee::widgets::MainEventController::MainEventController()
+{
+}
+
+lycee::widgets::MainEventController::MainEventController(const MainEventController &)
+{
+}
+
+lycee::widgets::MainEventController& lycee::widgets::MainEventController::operator =(const MainEventController &)
+{
+	return *this;
+}
+
+
+std::map<HWND, lycee::widgets::Application*> lycee::widgets::MainEventController::applicationList;
+
+LRESULT CALLBACK lycee::widgets::MainEventController::GlobalWndProc(HWND hWnd, UINT uMsg, WPARAM wp, LPARAM lp)
 {
 	if (uMsg == WM_CREATE) {
 		LPCREATESTRUCT lpcs = (LPCREATESTRUCT)lp;
@@ -22,9 +40,6 @@ LRESULT CALLBACK lycee::widgets::Application::MainEventController(HWND hWnd, UIN
 
 	if (uMsg == WM_DESTROY) {
 		applicationList.erase(iter);
-		if (applicationList.size() == 0) {
-			PostQuitMessage(0);
-		}
 	}
 
 	return lRes;


### PR DESCRIPTION
## 改修内容
ウィンドウメッセージのハンドリングを行うEventHandlerを追加

### クラスの変更理由
EventHandler追加当初( https://github.com/ryouka0122/lycee-filterflow/pull/6 )に予定していたHandlerは，WindowEventHandlerとWindowPainterが依存関係を持っていた．この関係を排除するために，EventHandler+CommonEventHandlerの2種類だけに縮小させて，それを利用するLyceeFilterFlowがWindowPainterを使うように切り替えた．

## やることリスト
* [x] Panelのクラス構成は見直す予定
* [x] Panelにドラッグ機能を追加
* [ ] ImageProcessorの作りこみ
* [ ] OpenCVとの連携
* [x] IO周りの作りこみ
* [ ] ダブルバッファリング処理
* [ ] ジョイントの描画処理の改善
* [ ] FilterFlowのfork/merge機能
* [ ] Panelのイベント処理

## 現在のクラス構造（概略）
![クラス図](https://user-images.githubusercontent.com/22113235/72673120-3cabd680-3aa9-11ea-80e0-a21fd643c184.png)

