### PR TITLE
Replace FilterGraph in LyceeFilterFlow

### DIFF
--- a/lycee-filterflow/LyceeFilterFlow.cpp
+++ b/lycee-filterflow/LyceeFilterFlow.cpp
@@ -9,8 +9,6 @@ lycee::LyceeFilterFlow::~LyceeFilterFlow()
 
 lycee::LyceeFilterFlow::LyceeFilterFlow(HINSTANCE hInstance)
 	: lycee::widgets::Application(hInstance),
-	input(NULL),
-	output(NULL),
 	filterList(),
 	eventHandler(DefWindowProc)
 {

--- a/lycee-filterflow/LyceeFilterFlow.cpp
+++ b/lycee-filterflow/LyceeFilterFlow.cpp
@@ -9,8 +9,14 @@ lycee::LyceeFilterFlow::~LyceeFilterFlow()
 
 lycee::LyceeFilterFlow::LyceeFilterFlow(HINSTANCE hInstance)
 	: lycee::widgets::Application(hInstance),
-	filterList(),
-	eventHandler(DefWindowProc)
+	graph(),
+	eventHandler(DefWindowProc),
+	isDragging(false),
+	ptStartMouse(),
+	ptStartPanel(),
+	draggingId(-1),
+	popupMenu(NULL),
+	ptBtnRight()
 {
 }
 
@@ -29,37 +35,4 @@ BOOL lycee::LyceeFilterFlow::start(const lycee_string &title, int width, int hei
 	entryEventHandler(&eventHandler);
 
 	return this->run(title, width, height, nCmdShow);
-}
-
-BOOL lycee::LyceeFilterFlow::renderEdge(lycee::graphics::WindowPainter *painter)
-{
-	lycee::graphics::Pen edge(lycee::filtergraph::PanelProfile::LINE_BASECOLOR, 1);
-	lycee::graphics::Pen line(lycee::filtergraph::PanelProfile::LINE_BASECOLOR, 1);
-	lycee::graphics::SolidBrush faceBegin(lycee::filtergraph::PanelProfile::LINE_BEGIN_FACECOLOR);
-	lycee::graphics::SolidBrush faceEnd(lycee::filtergraph::PanelProfile::LINE_END_FACECOLOR);
-
-	for (auto iter = jointList.begin(); iter != jointList.end(); iter++) {
-		std::optional<POINT> ptBegin = iter->first->getJointPt(filtergraph::JointType::OUTPUT);
-		std::optional<POINT >ptEnd = iter->second->getJointPt(filtergraph::JointType::INPUT);
-		if (!ptBegin || !ptEnd) continue;
-
-		POINT begin = ptBegin.value(), end = ptEnd.value();
-
-		POINT ptList[4] = {
-			begin,
-			POINT{ end.x, begin.y },
-			POINT{ begin.x, end.y },
-			end
-		};
-		painter->curve(line , 4, ptList);
-
-		std::function<RECT(POINT, int)> circleRect = [&](POINT pt, int r) {
-			return RECT{ pt.x - r, pt.y - r, pt.x + r, pt.y + r };
-		};
-
-		painter->ellipse(faceBegin, edge, circleRect(begin, lycee::filtergraph::PanelProfile::LINE_JOINT_RADIUS));
-		painter->ellipse(faceEnd, edge, circleRect(end, lycee::filtergraph::PanelProfile::LINE_JOINT_RADIUS));
-	}
-
-	return TRUE;
 }

--- a/lycee-filterflow/LyceeFilterFlow.h
+++ b/lycee-filterflow/LyceeFilterFlow.h
@@ -35,21 +35,17 @@ namespace lycee {
 		void setupEvent();
 
 	private:
-		std::deque<lycee::filtergraph::PanelViewFactory*> factories;
+		typedef std::pair<lycee::filtergraph::PanelView*, lycee::filtergraph::PanelView*> JointFlow;
 		
-		lycee::filtergraph::PanelView *input;
-		lycee::filtergraph::PanelView *output;
-
+		std::deque<lycee::filtergraph::PanelViewFactory*> factories;
 		std::deque<lycee::filtergraph::PanelView*> filterList;
+		std::deque<JointFlow> jointList;
 
 		bool isDragging;
 		POINT ptStartMouse;
 		POINT ptStartPanel;
 		lycee::filtergraph::PanelView *dragging;
-
-		typedef std::pair<lycee::filtergraph::PanelView*, lycee::filtergraph::PanelView*> JointFlow;
-		std::list<JointFlow> jointList;
-
+		
 		BOOL renderEdge(lycee::graphics::WindowPainter *painter);
 
 	private:

--- a/lycee-filterflow/LyceeFilterFlow.h
+++ b/lycee-filterflow/LyceeFilterFlow.h
@@ -35,19 +35,13 @@ namespace lycee {
 		void setupEvent();
 
 	private:
-		typedef std::pair<lycee::filtergraph::PanelView*, lycee::filtergraph::PanelView*> JointFlow;
-		
-		std::deque<lycee::filtergraph::PanelViewFactory*> factories;
-		std::deque<lycee::filtergraph::PanelView*> filterList;
-		std::deque<JointFlow> jointList;
+		lycee::filtergraph::FilterGraph graph;
 
 		bool isDragging;
 		POINT ptStartMouse;
 		POINT ptStartPanel;
-		lycee::filtergraph::PanelView *dragging;
+		int draggingId;
 		
-		BOOL renderEdge(lycee::graphics::WindowPainter *painter);
-
 	private:
 		lycee::widgets::FileSelectDialog fileSelectDialog;
 
@@ -62,6 +56,10 @@ namespace lycee {
 	private:
 		lycee::widgets::PopupMenu *popupMenu;
 		POINT ptBtnRight;
+		int targetDeleteId;
+
+		void setupPopupMenu();
+
 
 	};
 

--- a/lycee-filterflow/LyceeFilterFlow_Event.cpp
+++ b/lycee-filterflow/LyceeFilterFlow_Event.cpp
@@ -32,11 +32,9 @@ LRESULT lycee::LyceeFilterFlow::doClose(lycee::widgets::EventInfo info)
 
 LRESULT lycee::LyceeFilterFlow::doDestroy(lycee::widgets::EventInfo info)
 {
-	delete input;
 	for (auto iter = this->filterList.begin(); iter != this->filterList.end(); iter++) {
 		delete *iter;
 	}
-	delete output;
 
 	for (auto iter = factories.begin(); iter != factories.end(); iter++) {
 		delete (*iter);
@@ -50,23 +48,9 @@ LRESULT lycee::LyceeFilterFlow::doDestroy(lycee::widgets::EventInfo info)
 
 LRESULT lycee::LyceeFilterFlow::doCreate(lycee::widgets::EventInfo info)
 {
-	factories.push_back(new lycee::filtergraph::InputPanelViewFactory(TEXT("Input[%03d]")));
-	factories.push_back(new lycee::filtergraph::OutputPanelViewFactory(TEXT("Output[%03d]")));
-	factories.push_back(new lycee::filtergraph::FilterPanelViewFactory(TEXT("Filter[%03d]")));
-
-	input = factories[0]->create(POINT{ 100, 100 }, lycee::images::ImageProcessor::getDefault());
-	output = factories[1]->create(POINT{ 550, 300 }, lycee::images::ImageProcessor::getDefault());
-	filterList.push_back(
-		factories[2]->create(POINT{ 350, 100 }, lycee::images::ImageProcessor::getDefault()));
-	filterList.push_back(
-		factories[2]->create(POINT{ 700, 100 }, lycee::images::ImageProcessor::getDefault()));
-	filterList.push_back(
-		factories[2]->create(POINT{ 300, 300 }, lycee::images::ImageProcessor::getDefault()));
-
-	jointList.push_back(std::make_pair(input, filterList[0]));
-	jointList.push_back(std::make_pair(filterList[0], filterList[1]));
-	jointList.push_back(std::make_pair(input, filterList[2]));
-	jointList.push_back(std::make_pair(filterList[2], output));
+	factories.push_back(new lycee::filtergraph::InputPanelViewFactory());
+	factories.push_back(new lycee::filtergraph::OutputPanelViewFactory());
+	factories.push_back(new lycee::filtergraph::FilterPanelViewFactory());
 
 	fileSelectDialog
 		.title(TEXT("ファイルを選んで"))
@@ -77,7 +61,6 @@ LRESULT lycee::LyceeFilterFlow::doCreate(lycee::widgets::EventInfo info)
 		.filter(TEXT("gif"), TEXT("GIF Image"))
 		.filter(TEXT("*"), TEXT("All Files"));
 
-
 	popupMenu = lycee::widgets::PopupMenu::fromResource(this->getHINSTANCE(), IDR_MENU1);
 
 	return 0L;
@@ -87,12 +70,9 @@ LRESULT lycee::LyceeFilterFlow::doPaint(lycee::widgets::EventInfo info)
 {
 	lycee::graphics::WindowPainter painter(info.hWnd);
 
-	input->render(&painter);
 	for (auto iter = this->filterList.begin(); iter != this->filterList.end(); iter++) {
 		(*iter)->render(&painter);
 	}
-	output->render(&painter);
-
 	renderEdge(&painter);
 	return 0L;
 }
@@ -162,21 +142,7 @@ LRESULT lycee::LyceeFilterFlow::doLButtonDown(lycee::widgets::EventInfo info)
 	this->dragging = NULL;
 	this->isDragging = false;
 
-	if (input->hittest(x, y)) {
-		this->isDragging = true;
-		this->dragging = input;
-		this->ptStartMouse.x = x;
-		this->ptStartMouse.y = y;
-		this->ptStartPanel = input->getPosition();
-	}
-	else if (output->hittest(x, y)) {
-		this->isDragging = true;
-		this->dragging = output;
-		this->ptStartMouse.x = x;
-		this->ptStartMouse.y = y;
-		this->ptStartPanel = output->getPosition();
-	}
-	else for (auto iter = filterList.begin(); iter != filterList.end(); iter++) {
+	for (auto iter = filterList.begin(); iter != filterList.end(); iter++) {
 		auto panel = *iter;
 		if (panel->hittest(x, y)) {
 			this->isDragging = true;

--- a/lycee-filterflow/LyceeFilterFlow_Menu.cpp
+++ b/lycee-filterflow/LyceeFilterFlow_Menu.cpp
@@ -1,9 +1,19 @@
 #include "LyceeFilterFlow.h"
 
-
+#include "resource.h"
 
 LRESULT lycee::LyceeFilterFlow::doRButtonDown(lycee::widgets::EventInfo info)
 {
-	popupMenu->show(info.hWnd, POINT{LOWORD(info.lParam), HIWORD(info.lParam)});
+	ptBtnRight = POINT{ LOWORD(info.lParam), HIWORD(info.lParam) };
+	targetDeleteId = graph.hittest(ptBtnRight);
+	setupPopupMenu();
+
+	popupMenu->show(info.hWnd, ptBtnRight);
 	return 0L;
+}
+
+void lycee::LyceeFilterFlow::setupPopupMenu()
+{
+	popupMenu->state(ID__DELETEPANEL, (targetDeleteId != -1));
+
 }

--- a/lycee-filterflow/filtergraph/FilterGraph.cpp
+++ b/lycee-filterflow/filtergraph/FilterGraph.cpp
@@ -1,47 +1,130 @@
 #include "FilterGraph.h"
 
+#include "..\lycee.h"
 
 lycee::filtergraph::FilterGraph::~FilterGraph()
 {
+	removeAllPanelView();
 }
 
-lycee::filtergraph::FilterGraph::FilterGraph(HWND hTargetWnd)
-	: hWnd(hTargetWnd),
-	panelList(),
-	edgeList()
+lycee::filtergraph::FilterGraph::FilterGraph()
+	: panelViewList(),
+	connectorList(),
+	inputFactory(new lycee::filtergraph::InputPanelViewFactory()),
+	outputFactory(new lycee::filtergraph::OutputPanelViewFactory()),
+	filterFactory(new lycee::filtergraph::FilterPanelViewFactory())
 {
 }
 
-void lycee::filtergraph::FilterGraph::insertPanel(Panel *panel)
+void lycee::filtergraph::FilterGraph::add(int x, int y, PanelViewFactory *factory)
 {
-	this->panelList.push_back(panel);
+	PanelView *pv = factory->create(POINT{x, y}, lycee::images::ImageProcessor::getDefault());
+	panelViewList.push_back(pv);
 }
 
-void lycee::filtergraph::FilterGraph::joinPanel(panel_size_type begin, panel_size_type end)
+void lycee::filtergraph::FilterGraph::removePanelView(int id)
 {
-	this->edgeList.push_back(lycee::filtergraph::Edge{begin, end});
+	// erase connectors
+	auto iter = std::remove_if(connectorList.begin(), connectorList.end(), [&](Connector x) {
+		return x.fromId==id || x.toId==id;
+	});
+	connectorList.erase(iter, connectorList.end());
+
+	// erase panel
+	auto pvIter = panelViewList.begin() + id;
+	delete *pvIter;
+	panelViewList.erase(pvIter);
 }
 
-void lycee::filtergraph::FilterGraph::render(HDC hdc)
+void lycee::filtergraph::FilterGraph::removeAllPanelView() 
 {
-	lycee::graphics::WindowPainter painter(hdc);
-
-	for (auto iter = this->panelList.begin(); iter != this->panelList.end(); iter++) {
-		renderPanel(&painter, *iter);
+	for (auto iter = panelViewList.begin(); iter != panelViewList.end(); iter++) {
+		delete *iter;
 	}
+	panelViewList.clear();
+	connectorList.clear();
+}
 
-	for (auto iter = this->edgeList.begin(); iter != this->edgeList.end(); iter++) {
-		renderEdge(&painter, &(*iter));
+void lycee::filtergraph::FilterGraph::connect(int from, int to)
+{
+	connectorList.push_back(Connector{ from, to });
+}
+
+void lycee::filtergraph::FilterGraph::disconnect(int from, int to)
+{
+	auto iter = std::find_if(connectorList.begin(), connectorList.end(), [&](Connector x) {
+		return x.fromId == from && x.toId == to;
+	});
+	if (iter == connectorList.end()) {
+		return;
 	}
-
+	connectorList.erase(iter);
 }
 
-void lycee::filtergraph::FilterGraph::renderPanel(lycee::graphics::WindowPainter* painter, Panel *panel)
+bool lycee::filtergraph::FilterGraph::canConnect(int from, int to)
 {
-
+	auto iter = std::find_if(connectorList.begin(), connectorList.end(), [&](Connector x) {
+		return x.fromId == from && x.toId == to;
+	});
+	return (iter != connectorList.end());
 }
 
-void lycee::filtergraph::FilterGraph::renderEdge(lycee::graphics::WindowPainter* painter, Edge *edge)
+void lycee::filtergraph::FilterGraph::render(lycee::graphics::WindowPainter* painter)
 {
-	;
+	renderPanel(painter);
+	renderConnector(painter);
+}
+
+int lycee::filtergraph::FilterGraph::hittest(int x, int y)
+{
+	for (int i = 0, l = (int)panelViewList.size(); i < l; i++) {
+		if (HITTEST_TYPE::NONE != panelViewList[i]->hittest(x, y)) {
+			return i;
+		}
+	}
+	return -1;	// no hit anything.
+}
+
+void lycee::filtergraph::FilterGraph::renderPanel(lycee::graphics::WindowPainter* painter)
+{
+	for (auto iter = panelViewList.begin(); iter != panelViewList.end(); iter++) {
+		(*iter)->render(painter);
+	}
+}
+
+void lycee::filtergraph::FilterGraph::renderConnector(lycee::graphics::WindowPainter* painter)
+{
+	static std::function<RECT(POINT, int)> circleRect = [&](POINT pt, int r) {
+		return RECT{ pt.x - r, pt.y - r, pt.x + r, pt.y + r };
+	};
+
+	lycee::graphics::Pen edge(lycee::filtergraph::PanelProfile::LINE_BASECOLOR, 1);
+	lycee::graphics::Pen line(lycee::filtergraph::PanelProfile::LINE_BASECOLOR, 1);
+	lycee::graphics::SolidBrush faceBegin(lycee::filtergraph::PanelProfile::LINE_BEGIN_FACECOLOR);
+	lycee::graphics::SolidBrush faceEnd(lycee::filtergraph::PanelProfile::LINE_END_FACECOLOR);
+
+	for (auto iter = connectorList.begin(); iter != connectorList.end(); iter++) {
+		PanelView* from = panelViewList[iter->fromId];
+		PanelView* to = panelViewList[iter->toId];
+		
+		std::optional<POINT> ptBegin = from->getJointPt(JointType::OUTPUT);
+		if (!ptBegin) continue;
+		
+		std::optional<POINT> ptEnd = to->getJointPt(JointType::INPUT);
+		if (!ptEnd) continue;
+
+		POINT
+			begin = ptBegin.value(),
+			end = ptEnd.value(),
+			ptList[4] = {
+				begin,
+				POINT{ end.x, begin.y },
+				POINT{ begin.x, end.y },
+				end
+			};
+		painter->curve(line, 4, ptList);
+
+		painter->ellipse(faceBegin, edge, circleRect(begin, lycee::filtergraph::PanelProfile::LINE_JOINT_RADIUS));
+		painter->ellipse(faceEnd, edge, circleRect(end, lycee::filtergraph::PanelProfile::LINE_JOINT_RADIUS));
+	}
 }

--- a/lycee-filterflow/filtergraph/FilterGraph.h
+++ b/lycee-filterflow/filtergraph/FilterGraph.h
@@ -4,46 +4,65 @@
 #include "..\lycee.h"
 
 #include "Panels.h"
+#include "PanelViewFactory.h"
+
 
 namespace lycee {
 
 	namespace filtergraph {
 
 
-		struct Edge {
-			typedef typename std::list<Panel*>::size_type size_type;
-
-			size_type begin;
-			size_type end;
+		struct Connector {
+			int fromId;
+			int toId;
 		};
 
 
 		class FilterGraph {
 		public:
-			typedef typename std::list<Panel*>::size_type panel_size_type;
-			typedef typename std::list<Edge>::size_type edge_size_type;
-
 			virtual ~FilterGraph();
-			explicit FilterGraph(HWND hWnd);
-
-		private:
-			HWND hWnd;
+			FilterGraph();
 
 		public:
-			void insertPanel(Panel *panel);
-			void joinPanel(panel_size_type begin, panel_size_type end);
+			void addInput(int x, int y)
+			{
+				add(x, y, inputFactory);
+			}
 
-			void render(HDC hdc);
+			void addOutput(int x, int y)
+			{
+				add(x, y, outputFactory);
+			}
 
+			void addFilter(int x, int y)
+			{
+				add(x, y, filterFactory);
+			}
 
+			void removePanelView(int id);
+
+			void removeAllPanelView();
+
+			void connect(int from, int to);
+			void disconnect(int from, int to);
+			bool canConnect(int from, int to);
+
+			void render(lycee::graphics::WindowPainter* painter);
+
+			int hittest(int x, int y);
 
 		private:
-			std::list<Panel*> panelList;
-			std::list<Edge> edgeList;
+			PanelViewFactory *inputFactory;
+			PanelViewFactory *outputFactory;
+			PanelViewFactory *filterFactory;
 
-			void renderPanel(lycee::graphics::WindowPainter* painter, Panel *panel);
+			std::deque<PanelView*> panelViewList;
+			std::deque<Connector> connectorList;
 
-			void renderEdge(lycee::graphics::WindowPainter* painter, Edge *edge);
+			void add(int x, int y, PanelViewFactory* factory);
+
+			void renderPanel(lycee::graphics::WindowPainter* painter);
+			void renderConnector(lycee::graphics::WindowPainter* painter);
 
 		};
 

--- a/lycee-filterflow/filtergraph/FilterGraph.h
+++ b/lycee-filterflow/filtergraph/FilterGraph.h
@@ -51,6 +51,16 @@ namespace lycee {
 
 			int hittest(int x, int y);
 
+			int hittest(const POINT &pt)
+			{
+				return hittest(pt.x, pt.y);
+			}
+
+			PanelView* operator [](int index)
+			{
+				return panelViewList[index];
+			}
+
 		private:
 			PanelViewFactory *inputFactory;
 			PanelViewFactory *outputFactory;

--- a/lycee-filterflow/filtergraph/PanelViewFactory.cpp
+++ b/lycee-filterflow/filtergraph/PanelViewFactory.cpp
@@ -39,8 +39,8 @@ lycee::filtergraph::InputPanelViewFactory::~InputPanelViewFactory()
 	;
 }
 
-lycee::filtergraph::InputPanelViewFactory::InputPanelViewFactory(const lycee_string &nameTemplate)
-	: lycee::filtergraph::AbstractPanelViewFactory(nameTemplate)
+lycee::filtergraph::InputPanelViewFactory::InputPanelViewFactory()
+	: lycee::filtergraph::AbstractPanelViewFactory(TEXT("INPUT[%03d]"))
 {
 	;
 }
@@ -66,8 +66,8 @@ lycee::filtergraph::FilterPanelViewFactory::~FilterPanelViewFactory()
 }
 
 
-lycee::filtergraph::FilterPanelViewFactory::FilterPanelViewFactory(const lycee_string &nameTemplate)
-	: lycee::filtergraph::AbstractPanelViewFactory(nameTemplate)
+lycee::filtergraph::FilterPanelViewFactory::FilterPanelViewFactory()
+	: lycee::filtergraph::AbstractPanelViewFactory(TEXT("FILTER[%03d]"))
 {
 	;
 }
@@ -94,8 +94,8 @@ lycee::filtergraph::OutputPanelViewFactory::~OutputPanelViewFactory()
 	;
 }
 
-lycee::filtergraph::OutputPanelViewFactory::OutputPanelViewFactory(const lycee_string &nameTemplate)
-	: lycee::filtergraph::AbstractPanelViewFactory(nameTemplate)
+lycee::filtergraph::OutputPanelViewFactory::OutputPanelViewFactory()
+	: lycee::filtergraph::AbstractPanelViewFactory(TEXT("OUTPUT[%03d]"))
 {
 	;
 }

--- a/lycee-filterflow/filtergraph/PanelViewFactory.h
+++ b/lycee-filterflow/filtergraph/PanelViewFactory.h
@@ -33,7 +33,7 @@ namespace lycee {
 		class InputPanelViewFactory : virtual public AbstractPanelViewFactory {
 		public:
 			virtual ~InputPanelViewFactory();
-			explicit InputPanelViewFactory(const lycee_string &nameTemplate);
+			explicit InputPanelViewFactory();
 
 			virtual PanelView *create(const POINT &pos, lycee::images::ImageProcessor *processor);
 
@@ -43,7 +43,7 @@ namespace lycee {
 		class FilterPanelViewFactory : virtual public AbstractPanelViewFactory {
 		public:
 			virtual ~FilterPanelViewFactory();
-			explicit FilterPanelViewFactory(const lycee_string &nameTemplate);
+			explicit FilterPanelViewFactory();
 
 			virtual PanelView *create(const POINT &pos, lycee::images::ImageProcessor *processor);
 
@@ -53,7 +53,7 @@ namespace lycee {
 		class OutputPanelViewFactory : virtual public AbstractPanelViewFactory {
 		public:
 			virtual ~OutputPanelViewFactory();
-			explicit OutputPanelViewFactory(const lycee_string &nameTemplate);
+			explicit OutputPanelViewFactory();
 
 			virtual PanelView *create(const POINT &pos, lycee::images::ImageProcessor *processor);
 

--- a/lycee-filterflow/lycee/widgets/Menus.cpp
+++ b/lycee-filterflow/lycee/widgets/Menus.cpp
@@ -15,7 +15,18 @@ BOOL lycee::widgets::PopupMenu::show(HWND hWnd, const POINT &ptClient, UINT uFla
 {
 	POINT ptScreen = ptClient;
 	ClientToScreen(hWnd, &ptScreen);
-	return TrackPopupMenu(GetSubMenu(this->hContextMenu, 0), uFlags, ptScreen.x, ptScreen.y, 0, hWnd, NULL);
+	return TrackPopupMenu(GetSubMenu(hContextMenu, 0), uFlags, ptScreen.x, ptScreen.y, 0, hWnd, NULL);
+}
+
+lycee::widgets::PopupMenu& lycee::widgets::PopupMenu::state(UINT menuId, bool bState)
+{
+	MENUITEMINFO mii = { 0 };
+	mii.cbSize = sizeof(mii);
+	mii.fMask = MIIM_STATE;
+	GetMenuItemInfo(hContextMenu, menuId, FALSE, &mii);
+	mii.fState = bState ? MFS_ENABLED : MFS_GRAYED;
+	SetMenuItemInfo(hContextMenu, menuId, FALSE, &mii);
+	return *this;
 }
 
 lycee::widgets::PopupMenu* lycee::widgets::PopupMenu::fromResource(

--- a/lycee-filterflow/lycee/widgets/Menus.h
+++ b/lycee-filterflow/lycee/widgets/Menus.h
@@ -26,6 +26,19 @@ namespace lycee {
 			
 			BOOL show(HWND hWnd, const POINT &ptClient, UINT uFlags);
 
+			PopupMenu& enable(UINT menuId)
+			{
+				return state(menuId, true);
+			}
+
+			PopupMenu& disable(UINT menuId)
+			{
+				return state(menuId, false);
+			}
+			
+			PopupMenu& state(UINT menuId, bool bState);
+
+
 		private:
 			HMENU hContextMenu;
 			


### PR DESCRIPTION
## 改修内容
* LyceeFilterFlow内にある処理をFilterGraphに置き換えた
* コンテキストメニューを使って各種操作を実装
  * パネルの追加と削除
  * パネル上でのみ削除項目が活性化

## やることリスト
* [x] Panelのクラス構成は見直す予定
* [x] Panelにドラッグ機能を追加
* [ ] ImageProcessorの作りこみ
* [ ] OpenCVとの連携
* [x] IO周りの作りこみ
* [ ] ダブルバッファリング処理
* [ ] ジョイントの描画処理の改善
* [ ] FilterFlowのfork/merge機能
* [x] Panelのイベント処理

## ここまでの実装結果
![無題6](https://user-images.githubusercontent.com/22113235/72762005-5839ed00-3c21-11ea-8428-999d4f2a4ffe.png)

